### PR TITLE
Emit Go AST instead of plain text

### DIFF
--- a/internal/ccgo/ccgo.go
+++ b/internal/ccgo/ccgo.go
@@ -59,9 +59,9 @@ func main() {
 // Command outputs a Go program generated from in to w.
 //
 // No package or import clause is generated.
-func Command(w io.Writer, in []*c99.TranslationUnit) (err error) { return command(w, &in) }
+func Command(w io.Writer, in []*c99.TranslationUnit) (err error) { return command(w, "", &in) }
 
-func command(w io.Writer, in *[]*c99.TranslationUnit, more ...func(*[]byte) error) (err error) {
+func command(w io.Writer, fn string, in *[]*c99.TranslationUnit, more ...func(*[]byte) error) (err error) {
 	returned := false
 
 	defer func() {
@@ -70,7 +70,7 @@ func command(w io.Writer, in *[]*c99.TranslationUnit, more ...func(*[]byte) erro
 		}
 	}()
 
-	err = newGen(w, in).gen(true, more...)
+	err = newGen(w, in).gen(true, fn, more...)
 	returned = true
 	return err
 }
@@ -79,7 +79,7 @@ func command(w io.Writer, in *[]*c99.TranslationUnit, more ...func(*[]byte) erro
 //
 // No package or import clause is generated.
 func Package(w io.Writer, in []*c99.TranslationUnit) error {
-	return newGen(w, &in).gen(false)
+	return newGen(w, &in).gen(false, "")
 }
 
 type gen struct {
@@ -193,7 +193,7 @@ func env(key, val string) string {
 	return val
 }
 
-func (g *gen) gen(cmd bool, more ...func(*[]byte) error) (err error) {
+func (g *gen) gen(cmd bool, fn string, more ...func(*[]byte) error) (err error) {
 	if len(g.in) == 0 {
 		return fmt.Errorf("no translation unit passed")
 	}
@@ -308,7 +308,7 @@ const %s = uintptr(0)
 	}
 	g.w("\")\n)\n")
 	g.in = nil
-	return newOpt().do(g.out, &g.out0, testFn, g.needBool2int, more...)
+	return newOpt().do(g.out, &g.out0, fn, g.needBool2int, more...)
 }
 
 // dbg only

--- a/internal/ccgo/decl.go
+++ b/internal/ccgo/decl.go
@@ -10,9 +10,12 @@ import (
 
 	"github.com/cznic/ir"
 	"github.com/cznic/sqlite2go/internal/c99"
+	"go/ast"
+	"strconv"
 )
 
-func (g *gen) define(n *c99.Declarator) {
+func (g *gen) define(n *c99.Declarator) []ast.Decl {
+	var out []ast.Decl
 more:
 	n = g.normalizeDeclarator(n)
 	defined := true
@@ -21,7 +24,7 @@ more:
 	}
 	if _, ok := g.producedDeclarators[n]; defined && !ok {
 		g.producedDeclarators[n] = struct{}{}
-		g.tld(n)
+		out = append(out, g.tld(n)...)
 	}
 
 	for g.queue.Front() != nil {
@@ -32,20 +35,20 @@ more:
 			n = y
 			goto more
 		case *c99.EnumType:
-			g.defineEnumType(y)
+			out = append(out, g.defineEnumType(y)...)
 		case *c99.NamedType:
 			switch z := underlyingType(y.Type, true).(type) {
 			case *c99.StructType:
 				switch {
 				case z.Tag == 0:
-					g.defineNamedType(y)
+					out = append(out, g.defineNamedType(y)...)
 				default:
 					g.enqueue(y.Type)
 				}
 			case *c99.UnionType:
 				switch {
 				case z.Tag == 0:
-					g.defineNamedType(y)
+					out = append(out, g.defineNamedType(y)...)
 				default:
 					g.enqueue(y.Type)
 				}
@@ -53,11 +56,11 @@ more:
 				g.enqueue(y.Type)
 			}
 		case *c99.TaggedEnumType:
-			g.defineTaggedEnumType(y)
+			out = append(out, g.defineTaggedEnumType(y)...)
 		case *c99.TaggedStructType:
-			g.defineTaggedStructType(y)
+			out = append(out, g.defineTaggedStructType(y)...)
 		case *c99.TaggedUnionType:
-			g.defineTaggedUnionType(y)
+			out = append(out, g.defineTaggedUnionType(y)...)
 		case
 			*c99.ArrayType,
 			*c99.FunctionType,
@@ -71,71 +74,97 @@ more:
 			todo("%T %v", y, y)
 		}
 	}
+	return out
 }
 
-func (g *gen) defineEnumType(t *c99.EnumType) {
-	if t.Tag != 0 {
-		g.defineTaggedEnumType(&c99.TaggedEnumType{Tag: t.Tag, Type: t})
+func (g *gen) defineEnumType(t *c99.EnumType) []ast.Decl {
+	if t.Tag == 0 {
+		return nil
 	}
+	return g.defineTaggedEnumType(&c99.TaggedEnumType{Tag: t.Tag, Type: t})
 }
 
-func (g *gen) defineTaggedEnumType(t *c99.TaggedEnumType) {
+func (g *gen) defineTaggedEnumType(t *c99.TaggedEnumType) []ast.Decl {
 	if _, ok := g.producedEnumTags[t.Tag]; ok {
-		return
+		return nil
 	}
 
 	g.producedEnumTags[t.Tag] = struct{}{}
 	et := t.Type.(*c99.EnumType)
-	tag := dict.S(t.Tag)
-	g.w("\ntype E%s = %s\n", tag, g.typ(et.Enums[0].Operand.Type))
-	g.w("\nconst (")
-	var iota int64
+	tag := string(dict.S(t.Tag))
+
+	var (
+		iota  int64
+		specs []ast.Spec
+	)
 	for i, v := range et.Enums {
 		val := v.Operand.Value.(*ir.Int64Value).Value
 		if i == 0 {
-			g.w("\nC%s E%s = iota", dict.S(v.Token.Val), tag)
-			if val != 0 {
-				g.w(" %+d", val)
+			var ev ast.Expr = ident("iota")
+			if val > 0 {
+				ev = add(ev, intLit(val))
+			} else if val < 0 {
+				ev = sub(ev, intLit(-val))
 			}
+			specs = append(specs, valSpec(
+				"C"+string(dict.S(v.Token.Val)),
+				ident("E"+tag),
+				ev,
+			))
 			iota = val + 1
 			continue
 		}
 
-		g.w("\nC%s", dict.S(v.Token.Val))
-		if val == iota {
+		var ev ast.Expr
+		if val != iota {
+			ev = intLit(val)
+			iota = val + 1
+		} else {
 			iota++
-			continue
 		}
-
-		g.w(" = %d", val)
-		iota = val + 1
+		specs = append(specs, valSpec(
+			"C"+string(dict.S(v.Token.Val)),
+			nil,
+			ev,
+		))
 	}
-	g.w("\n)\n")
-
+	return []ast.Decl{
+		typeAlias(
+			"E"+tag,
+			g.typ(et.Enums[0].Operand.Type),
+		),
+		consts(specs...),
+	}
 }
 
-func (g *gen) defineNamedType(t *c99.NamedType) {
+func (g *gen) defineNamedType(t *c99.NamedType) []ast.Decl {
 	if _, ok := g.producedNamedTypes[t.Name]; ok {
-		return
+		return nil
 	}
 
 	g.producedNamedTypes[t.Name] = struct{}{}
-	g.w("\ntype T%s = %s\n", dict.S(t.Name), g.typ(t.Type))
+	decl := typeAlias("T"+string(dict.S(t.Name)), g.typ(t.Type))
+	return []ast.Decl{decl}
 }
 
-func (g *gen) defineTaggedStructType(t *c99.TaggedStructType) {
+func (g *gen) defineTaggedStructType(t *c99.TaggedStructType) []ast.Decl {
 	if _, ok := g.producedStructTags[t.Tag]; ok {
-		return
+		return nil
 	}
 
 	switch {
 	case t.Type == nil:
 		g.opaqueStructTags[t.Tag] = struct{}{}
+		return nil
 	default:
 		g.producedStructTags[t.Tag] = struct{}{}
-		g.w("\ntype S%s %s\n", dict.S(t.Tag), g.typ(t.Type))
+		var out []ast.Decl
+		out = append(out, typeDef(
+			"S"+string(dict.S(t.Tag)),
+			g.typ(t.Type),
+		))
 		if isTesting {
-			g.w("\n\nfunc init() {")
+			var body []ast.Stmt
 			st := c99.UnderlyingType(t.Type).(*c99.StructType)
 			fields := st.Fields
 			for i, v := range g.model.Layout(st) {
@@ -148,43 +177,57 @@ func (g *gen) defineTaggedStructType(t *c99.TaggedStructType) {
 				}
 
 				if v.Bits != 0 && v.Bitoff == 0 {
-					g.w("\nif n := unsafe.Offsetof(S%s{}.F%d); n != %d { panic(n) }", dict.S(t.Tag), v.Offset, v.Offset)
-					g.w("\nif n := unsafe.Sizeof(S%s{}.F%d); n != %d { panic(n) }", dict.S(t.Tag), v.Offset, g.model.Sizeof(v.PackedType))
+					body = append(body, structOffsetTests(
+						"S"+string(dict.S(t.Tag)),
+						"F"+strconv.FormatInt(v.Offset, 10),
+						v.Offset, g.model.Sizeof(v.PackedType),
+					)...)
 					continue
 				}
 
 				if fields[i].Name == 0 {
 					continue
 				}
-
-				g.w("\nif n := unsafe.Offsetof(S%s{}.%s); n != %d { panic(n) }", dict.S(t.Tag), mangleIdent(fields[i].Name, true), v.Offset)
-				g.w("\nif n := unsafe.Sizeof(S%s{}.%s); n != %d { panic(n) }", dict.S(t.Tag), mangleIdent(fields[i].Name, true), v.Size)
+				body = append(body, structOffsetTests(
+					"S"+string(dict.S(t.Tag)),
+					mangleIdent(fields[i].Name, true),
+					v.Offset, v.Size,
+				)...)
 			}
-			g.w("\n}\n")
+			out = append(out, initFunc(body...))
 		}
+		return out
 	}
 }
 
-func (g *gen) defineTaggedUnionType(t *c99.TaggedUnionType) {
+func (g *gen) defineTaggedUnionType(t *c99.TaggedUnionType) []ast.Decl {
 	if _, ok := g.producedStructTags[t.Tag]; ok {
-		return
+		return nil
 	}
 
 	g.producedStructTags[t.Tag] = struct{}{}
-	g.w("\ntype U%s %s\n", dict.S(t.Tag), g.typ(t.Type))
-	if isTesting {
-		g.w("\n\nfunc init() {")
-		g.w("\nif n := unsafe.Sizeof(U%s{}); n != %d { panic(n) }", dict.S(t.Tag), g.model.Sizeof(t))
-		g.w("\n}\n")
+
+	var out []ast.Decl
+	out = append(out, typeDef(
+		"U"+string(dict.S(t.Tag)),
+		g.typ(t.Type),
+	))
+	if !isTesting {
+		out = append(out, initFunc(
+			assertSizeof(
+				compositeLit("U"+string(dict.S(t.Tag))),
+				g.model.Sizeof(t),
+			),
+		))
 	}
+	return out
 }
 
-func (g *gen) tld(n *c99.Declarator) {
+func (g *gen) tld(n *c99.Declarator) (out []ast.Decl) {
 	nm := n.Name()
 	t := c99.UnderlyingType(n.Type)
 	if t.Kind() == c99.Function {
-		g.functionDefinition(n)
-		return
+		return g.functionDefinition(n)
 	}
 
 	switch x := n.Type.(type) {
@@ -201,32 +244,49 @@ func (g *gen) tld(n *c99.Declarator) {
 	if !isTesting {
 		pos.Filename = filepath.Base(pos.Filename)
 	}
-	g.w("\n\n// %s %s, escapes: %v, %v", g.mangleDeclarator(n), g.typeComment(n.Type), g.escaped(n), pos)
+	defer func() {
+		if len(out) != 0 {
+			out[0] = commentDeclf(out[0], "%s %s, escapes: %v, %v",
+				g.mangleDeclarator(n), g.typeComment(n.Type), g.escaped(n), pos,
+			)
+		}
+	}()
+
 	if n.Initializer != nil && n.Linkage == c99.LinkageExternal {
 		g.initializedExterns[nm] = struct{}{}
 	}
 	if g.isZeroInitializer(n.Initializer) {
 		if isVaList(n.Type) {
-			g.w("\nvar %s *[]interface{}", g.mangleDeclarator(n))
+			out = append(out, varDecl(
+				g.mangleDeclarator(n),
+				ptr(sliceOf(emptyInf())),
+				nil,
+			))
 			return
 		}
 
 		if g.escaped(n) {
-			g.w("\nvar %s = bss + %d", g.mangleDeclarator(n), g.allocBSS(n.Type))
+			out = append(out, g.bssVarFor(n))
 			return
 		}
 
 		switch x := t.(type) {
 		case *c99.StructType:
-			g.w("\nvar %s = bss + %d\n", g.mangleDeclarator(n), g.allocBSS(n.Type))
+			out = append(out, g.bssVarFor(n))
 		case *c99.PointerType:
-			g.w("\nvar %s uintptr\n", g.mangleDeclarator(n))
+			out = append(out, varDecl(
+				g.mangleDeclarator(n), ident("uintptr"), nil,
+			))
 		case
 			*c99.EnumType,
 			c99.TypeKind:
 
 			if x.IsArithmeticType() {
-				g.w("\nvar %s %s\n", g.mangleDeclarator(n), g.typ(n.Type))
+				out = append(out, varDecl(
+					g.mangleDeclarator(n),
+					g.typI(n.Type),
+					nil,
+				))
 				break
 			}
 
@@ -238,43 +298,56 @@ func (g *gen) tld(n *c99.Declarator) {
 	}
 
 	if g.escaped(n) {
-		g.escapedTLD(n)
-		return
+		out = append(out, g.escapedTLD(n)...)
+		return out
 	}
 
 	switch n.Initializer.Case {
 	case c99.InitializerExpr: // Expr
-		g.w("\nvar %s = ", g.mangleDeclarator(n))
-		g.convert(n.Initializer.Expr, n.Type)
-		g.w("\n")
+		out = append(out, varDecl(
+			g.mangleDeclarator(n),
+			nil,
+			g.convert(n.Initializer.Expr, n.Type),
+		))
 	default:
 		todo("", g.position0(n), n.Initializer.Case)
 	}
+	return out
 }
 
-func (g *gen) escapedTLD(n *c99.Declarator) {
+func (g *gen) escapedTLD(n *c99.Declarator) []ast.Decl {
 	if g.isConstInitializer(n.Type, n.Initializer) {
-		g.w("\nvar %s = ds + %d\n", g.mangleDeclarator(n), g.allocDS(n.Type, n.Initializer))
-		return
+		return []ast.Decl{varDecl(
+			g.mangleDeclarator(n), nil,
+			addInt(ident("ds"), g.allocDS(n.Type, n.Initializer)),
+		)}
 	}
 
 	switch x := c99.UnderlyingType(n.Type).(type) {
 	case *c99.ArrayType:
 		if x.Item.Kind() == c99.Char && n.Initializer.Expr.Operand.Value != nil {
-			g.w("\nvar %s = ds + %d\n", g.mangleDeclarator(n), g.allocDS(n.Type, n.Initializer))
-			return
+			return []ast.Decl{varDecl(
+				g.mangleDeclarator(n), nil,
+				addInt(ident("ds"), g.allocDS(n.Type, n.Initializer)),
+			)}
 		}
 	}
 
-	g.w("\nvar %s = bss + %d // %v \n", g.mangleDeclarator(n), g.allocBSS(n.Type), n.Type)
-	g.w("\n\nfunc init() { *(*%s)(unsafe.Pointer(%s)) = ", g.typ(n.Type), g.mangleDeclarator(n))
-	g.literal(n.Type, n.Initializer)
-	g.w("}")
+	return []ast.Decl{
+		commentDeclf(g.bssVarFor(n), "%v", n.Type),
+		initFunc(
+			setPtrUnsafe(
+				g.typ(n.Type),
+				g.mangleDeclaratorI(n),
+				g.literal(n.Type, n.Initializer),
+			),
+		),
+	}
 }
 
-func (g *gen) functionDefinition(n *c99.Declarator) {
+func (g *gen) functionDefinition(n *c99.Declarator) []ast.Decl {
 	if n.FunctionDefinition == nil {
-		return
+		return nil
 	}
 
 	g.mainFn = n.Name() == idMain && n.Linkage == c99.LinkageExternal
@@ -284,8 +357,7 @@ func (g *gen) functionDefinition(n *c99.Declarator) {
 	if !isTesting {
 		pos.Filename = filepath.Base(pos.Filename)
 	}
-	g.w("\n\n// %s is defined at %v", g.mangleDeclarator(n), pos)
-	g.w("\nfunc %s(tls %sTLS", g.mangleDeclarator(n), crt)
+
 	names := n.ParameterNames()
 	t := n.Type.(*c99.FunctionType)
 	switch {
@@ -307,14 +379,17 @@ func (g *gen) functionDefinition(n *c99.Declarator) {
 
 		names = make([]int, len(t.Params))
 	}
+	var (
+		escParams []*c99.Declarator
+		par       []*ast.Field
+	)
 	params := n.Parameters
-	var escParams []*c99.Declarator
 	_, ok := g.fixArgs[n]
 	switch {
 	case len(t.Params) == 1 && t.Params[0].Kind() == c99.Void:
 		// nop
 	case ok:
-		g.w(", _ ...interface{}")
+		par = append(par, field("_", variadic(emptyInf()), nil))
 	default:
 		for i, v := range t.Params {
 			var param *c99.Declarator
@@ -322,55 +397,86 @@ func (g *gen) functionDefinition(n *c99.Declarator) {
 				param = params[i]
 			}
 			nm := names[i]
-			g.w(", ")
+
 			switch {
 			case param != nil && g.escaped(param):
-				g.w("a%s %s", dict.S(nm), g.typ(v))
+				par = append(par, field(
+					"a"+string(dict.S(nm)),
+					g.typI(v), nil,
+				))
 				escParams = append(escParams, param)
 			default:
+				var comment *ast.CommentGroup
+				if v.Kind() == c99.Ptr {
+					comment = commentf("%s", g.typeComment(v))
+				}
 				switch c99.UnderlyingType(v).(type) {
 				case *c99.ArrayType:
-					g.w("%s uintptr /* %v */ ", mangleIdent(nm, false), g.typ(v))
+					comment = commentf("%v", g.typ(v))
+					par = append(par, field(
+						mangleIdent(nm, false),
+						ident("uintptr"),
+						comment,
+					))
 				default:
-					g.w("%s %s ", mangleIdent(nm, false), g.typ(v))
-				}
-				if isVaList(v) {
-					continue
+					if isVaList(v) {
+						comment = nil
+					}
+					par = append(par, field(
+						mangleIdent(nm, false),
+						g.typI(v),
+						comment,
+					))
 				}
 
-				if v.Kind() == c99.Ptr {
-					g.w("/* %s */", g.typeComment(v))
-				}
 			}
 		}
 		if t.Variadic {
-			g.w(", %s...interface{}", ap)
+			par = append(par, field(ap, variadic(emptyInf()), nil))
 		}
 	}
-	g.w(")")
+
+	// return value
 	void := t.Result.Kind() == c99.Void
+	var ret []*ast.Field
 	if !void {
-		g.w("(r %s", g.typ(t.Result))
+		var comment *ast.CommentGroup
 		if t.Result.Kind() == c99.Ptr {
-			g.w("/* %s */", g.typeComment(t.Result))
+			comment = commentf("%s", g.typeComment(t.Result))
 		}
-		g.w(")")
+		ret = append(ret, field("r", g.typI(t.Result), comment))
 	}
+
+	// local vars
 	vars := n.FunctionDefinition.LocalVariables()
 	if n.Alloca {
 		vars = append(append([]*c99.Declarator(nil), vars...), allocaDeclarator)
 	}
-	g.functionBody(n.FunctionDefinition.FunctionBody, vars, void, n.Parameters, escParams)
-	g.w("\n")
+
+	// final declaration
+	fdecl := funcDecl(
+		g.mangleDeclarator(n),
+		par, ret,
+		g.functionBody(n.FunctionDefinition.FunctionBody, vars, void, n.Parameters, escParams),
+	)
+	return []ast.Decl{
+		commentDeclf(
+			withTLS(fdecl),
+			"%s is defined at %v", g.mangleDeclarator(n), pos,
+		),
+	}
 }
 
-func (g *gen) functionBody(n *c99.FunctionBody, vars []*c99.Declarator, void bool, params, escParams []*c99.Declarator) {
+func (g *gen) functionBody(n *c99.FunctionBody, vars []*c99.Declarator, void bool, params, escParams []*c99.Declarator) *ast.BlockStmt {
 	if vars == nil {
 		vars = []*c99.Declarator{}
 	}
-	g.compoundStmt(n.CompoundStmt, vars, nil, !void, nil, nil, params, escParams, false)
+	return block(g.compoundStmt(n.CompoundStmt, vars, nil, !void, nil, nil, params, escParams, false)...)
 }
 
+func (g *gen) mangleDeclaratorI(n *c99.Declarator) *ast.Ident {
+	return ident(g.mangleDeclarator(n))
+}
 func (g *gen) mangleDeclarator(n *c99.Declarator) string {
 	nm := n.Name()
 	if n.Linkage == c99.LinkageInternal {
@@ -417,36 +523,39 @@ func (g *gen) normalizeDeclarator(n *c99.Declarator) *c99.Declarator {
 	return n
 }
 
-func (g *gen) declaration(n *c99.Declaration, deadCode *bool) {
+func (g *gen) declaration(n *c99.Declaration, deadCode *bool) []ast.Stmt {
 	// DeclarationSpecifiers InitDeclaratorListOpt ';'
-	g.initDeclaratorListOpt(n.InitDeclaratorListOpt, deadCode)
+	return g.initDeclaratorListOpt(n.InitDeclaratorListOpt, deadCode)
 }
 
-func (g *gen) initDeclaratorListOpt(n *c99.InitDeclaratorListOpt, deadCode *bool) {
+func (g *gen) initDeclaratorListOpt(n *c99.InitDeclaratorListOpt, deadCode *bool) []ast.Stmt {
 	if n == nil {
-		return
+		return nil
 	}
 
-	g.initDeclaratorList(n.InitDeclaratorList, deadCode)
+	return g.initDeclaratorList(n.InitDeclaratorList, deadCode)
 }
 
-func (g *gen) initDeclaratorList(n *c99.InitDeclaratorList, deadCode *bool) {
+func (g *gen) initDeclaratorList(n *c99.InitDeclaratorList, deadCode *bool) []ast.Stmt {
+	var out []ast.Stmt
 	for ; n != nil; n = n.InitDeclaratorList {
-		g.initDeclarator(n.InitDeclarator, deadCode)
+		out = append(out, g.initDeclarator(n.InitDeclarator, deadCode)...)
 	}
+	return out
 }
 
-func (g *gen) initDeclarator(n *c99.InitDeclarator, deadCode *bool) {
+func (g *gen) initDeclarator(n *c99.InitDeclarator, deadCode *bool) []ast.Stmt {
 	d := n.Declarator
 	if d.DeclarationSpecifier.IsStatic() {
-		return
+		return nil
 	}
 
 	if d.Referenced == 0 && d.Initializer == nil {
-		return
+		return nil
 	}
 
 	if n.Case == c99.InitDeclaratorInit { // Declarator '=' Initializer
-		g.initializer(d)
+		return g.initializer(d)
 	}
+	return nil
 }

--- a/internal/ccgo/etc.go
+++ b/internal/ccgo/etc.go
@@ -24,7 +24,8 @@ import (
 
 const (
 	ap   = "ap"
-	crt  = "crt."
+	crtP = "crt"
+	crt  = crtP + "."
 	null = "null"
 )
 

--- a/internal/ccgo/etc.go
+++ b/internal/ccgo/etc.go
@@ -44,7 +44,6 @@ var (
 	idVaList                 = dict.SID("va_list")
 	idVaStart                = dict.SID("__va_start")
 
-	testFn      string
 	traceOpt    bool
 	traceTODO   bool
 	traceWrites bool

--- a/internal/ccgo/goast.go
+++ b/internal/ccgo/goast.go
@@ -1,0 +1,757 @@
+// Copyright 2018 The CCGO Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ccgo
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"io"
+	"strconv"
+	"strings"
+)
+
+func ident(name string) *ast.Ident {
+	return &ast.Ident{Name: name}
+}
+
+func binaryExpr(a ast.Expr, op token.Token, b ast.Expr) ast.Expr {
+	if _, ok := a.(*ast.BinaryExpr); ok {
+		a = paren(a)
+	}
+	if _, ok := b.(*ast.BinaryExpr); ok {
+		b = paren(b)
+	}
+	return &ast.BinaryExpr{
+		X: a, Op: op, Y: b,
+	}
+}
+
+func unaryExpr(op token.Token, a ast.Expr) ast.Expr {
+	return &ast.UnaryExpr{
+		X: a, Op: op,
+	}
+}
+
+func eq(a, b ast.Expr) ast.Expr {
+	return binaryExpr(a, token.EQL, b)
+}
+
+func neq(a, b ast.Expr) ast.Expr {
+	return binaryExpr(a, token.NEQ, b)
+}
+
+func add(a, b ast.Expr) ast.Expr {
+	return binaryExpr(a, token.ADD, b)
+}
+
+func sub(a, b ast.Expr) ast.Expr {
+	return binaryExpr(a, token.SUB, b)
+}
+
+func mul(a, b ast.Expr) ast.Expr {
+	return binaryExpr(a, token.MUL, b)
+}
+
+func div(a, b ast.Expr) ast.Expr {
+	return binaryExpr(a, token.QUO, b)
+}
+
+func shle(a, n ast.Expr) ast.Expr {
+	return binaryExpr(a, token.SHL, n)
+}
+
+func shre(a, n ast.Expr) ast.Expr {
+	return binaryExpr(a, token.SHR, n)
+}
+
+func shl(a ast.Expr, n int) ast.Expr {
+	return shle(a, intLit(int64(n)))
+}
+
+func shr(a ast.Expr, n int) ast.Expr {
+	return shre(a, intLit(int64(n)))
+}
+
+func inc(a ast.Expr) ast.Stmt {
+	return &ast.IncDecStmt{
+		Tok: token.INC, X: a,
+	}
+}
+
+func dec(a ast.Expr) ast.Stmt {
+	return &ast.IncDecStmt{
+		Tok: token.DEC, X: a,
+	}
+}
+
+func incn(a ast.Expr, n int64) ast.Stmt {
+	return &ast.AssignStmt{
+		Tok: token.ADD_ASSIGN,
+		Lhs: []ast.Expr{a},
+		Rhs: []ast.Expr{intLit(n)},
+	}
+}
+
+func decn(a ast.Expr, n int64) ast.Stmt {
+	return &ast.AssignStmt{
+		Tok: token.SUB_ASSIGN,
+		Lhs: []ast.Expr{a},
+		Rhs: []ast.Expr{intLit(n)},
+	}
+}
+
+func addInt(a ast.Expr, v int64) ast.Expr {
+	if v == 0 {
+		return a
+	}
+	return add(a, intLit(v))
+}
+
+func eqZero(a ast.Expr) ast.Expr {
+	return eq(a, intLit(0))
+}
+
+func neqZero(a ast.Expr) ast.Expr {
+	return neq(a, intLit(0))
+}
+
+func takeAddr(x ast.Expr) ast.Expr {
+	return unaryExpr(token.AND, x)
+}
+
+func ptrVal(x ast.Expr) ast.Expr {
+	return &ast.StarExpr{X: x}
+}
+
+func index(x, n ast.Expr) ast.Expr {
+	return &ast.IndexExpr{X: x, Index: n}
+}
+
+func ptr(x ast.Expr) ast.Expr {
+	return &ast.StarExpr{X: x}
+}
+
+func paren(x ast.Expr) ast.Expr {
+	switch x := x.(type) {
+	case *ast.ParenExpr, *ast.CallExpr, *ast.Ident, *ast.BasicLit:
+		return x
+	}
+	return &ast.ParenExpr{X: x}
+}
+
+func sliceTyp(name string) ast.Expr {
+	return sliceOf(ident(name))
+}
+
+func arrayTyp(name string, n int) ast.Expr {
+	return &ast.ArrayType{Elt: ident(name), Len: intLit(int64(n))}
+}
+
+func emptyInf() ast.Expr {
+	return ident("interface{}")
+}
+
+func unsafePtr() ast.Expr {
+	return sel(ident("unsafe"), "Pointer")
+}
+
+func uintPtr() ast.Expr {
+	return ident("uintptr")
+}
+
+func toUnsafePtr(x ast.Expr) ast.Expr {
+	return cast(
+		x, unsafePtr(),
+	)
+}
+
+func toUintptr(x ast.Expr) ast.Expr {
+	return cast(
+		x, uintPtr(),
+	)
+}
+
+func toUintptrMul(x ast.Expr, n int64) ast.Expr {
+	return mul(intLit(n), toUintptr(x))
+}
+
+func sliceOf(x ast.Expr) ast.Expr {
+	return &ast.ArrayType{Elt: x}
+}
+
+func variadic(x ast.Expr) ast.Expr {
+	return &ast.Ellipsis{Elt: x}
+}
+
+func typeAlias(name, typ string) ast.Decl {
+	// type A = B
+	return &ast.GenDecl{
+		Tok: token.TYPE,
+		Specs: []ast.Spec{&ast.TypeSpec{
+			Name:   ident(name),
+			Type:   ident(typ),
+			Assign: 1,
+		}},
+	}
+}
+
+func typeDef(name, typ string) ast.Decl {
+	// type A B
+	return &ast.GenDecl{
+		Tok: token.TYPE,
+		Specs: []ast.Spec{&ast.TypeSpec{
+			Name: ident(name),
+			Type: ident(typ),
+		}},
+	}
+}
+
+func varDecl(name string, typ, v ast.Expr) ast.Decl {
+	return defineVars(valSpec(name, typ, v))
+}
+
+func declStmt(d ast.Decl) ast.Stmt {
+	return &ast.DeclStmt{Decl: d}
+}
+
+func valSpec(name string, typ, v ast.Expr) ast.Spec {
+	var vals []ast.Expr
+	if v != nil {
+		vals = []ast.Expr{v}
+	}
+	return &ast.ValueSpec{
+		Names: []*ast.Ident{
+			ident(name),
+		},
+		Type: typ, Values: vals,
+	}
+}
+
+func defineVars(specs ...ast.Spec) ast.Decl {
+	d := &ast.GenDecl{
+		Tok:   token.VAR,
+		Specs: specs,
+	}
+	if len(specs) > 1 {
+		d.Lparen = 1
+		d.Rparen = 1
+	}
+	return d
+}
+
+func constSpec(name string, v ast.Expr) ast.Spec {
+	return valSpec(name, nil, v)
+}
+
+func consts(specs ...ast.Spec) ast.Decl {
+	return &ast.GenDecl{
+		Tok:   token.CONST,
+		Specs: specs,
+	}
+}
+
+func block(stmts ...ast.Stmt) *ast.BlockStmt {
+	return &ast.BlockStmt{List: stmts}
+}
+
+func ifStmt(cond ast.Expr, stmts ...ast.Stmt) ast.Stmt {
+	return &ast.IfStmt{
+		Cond: cond,
+		Body: block(stmts...),
+	}
+}
+
+func ifElseStmt(cond ast.Expr, then, els []ast.Stmt) ast.Stmt {
+	return &ast.IfStmt{
+		Cond: cond,
+		Body: block(then...),
+		Else: block(els...),
+	}
+}
+
+func field(name string, typ ast.Expr, comment *ast.CommentGroup) *ast.Field {
+	f := &ast.Field{Type: typ, Doc: comment}
+	if name != "" {
+		f.Names = []*ast.Ident{ident(name)}
+	}
+	if comment != nil && len(comment.List) != 0 {
+		c := comment.List[0]
+		if strings.HasPrefix(c.Text, "//") {
+			c.Text = "/*" + strings.TrimPrefix(c.Text, "//") + " */"
+		}
+	}
+	return f
+}
+
+func initFunc(stmts ...ast.Stmt) ast.Decl {
+	// func init() { ..stmts.. }
+	return voidFunc("init", stmts...)
+}
+
+func voidFunc(name string, stmts ...ast.Stmt) ast.Decl {
+	// func name() { ..stmts.. }
+	return funcDecl(name, nil, nil, block(stmts...))
+}
+
+func funcDecl(name string, par, ret []*ast.Field, body *ast.BlockStmt) *ast.FuncDecl {
+	return &ast.FuncDecl{
+		Name: ident(name),
+		Type: &ast.FuncType{
+			Params:  &ast.FieldList{List: par},
+			Results: &ast.FieldList{List: ret},
+		},
+		Body: body,
+	}
+}
+
+func assignStmt(a ast.Expr, tok token.Token, b ast.Expr) ast.Stmt {
+	return &ast.AssignStmt{
+		Lhs: []ast.Expr{a},
+		Tok: tok,
+		Rhs: []ast.Expr{b},
+	}
+}
+
+func define(a, b ast.Expr) ast.Stmt {
+	return assignStmt(a, token.DEFINE, b)
+}
+
+func assign(a, b ast.Expr) ast.Stmt {
+	if b == nil {
+		b = ident("nil")
+	}
+	return assignStmt(a, token.ASSIGN, b)
+}
+
+func assertStmt(val, exp ast.Expr) ast.Stmt {
+	// if n := %val; n != %exp { panic(n) }
+	v := ident("n")
+	return &ast.IfStmt{
+		Init: define(v, val),
+		Cond: neq(v, exp),
+		Body: block(
+			callPanic(v),
+		),
+	}
+}
+
+func intLit(v int64) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: strconv.FormatInt(v, 10),
+	}
+}
+
+func intLitF(f string, v int64) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: fmt.Sprintf(f, v),
+	}
+}
+
+func uintLit(v uint64) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: strconv.FormatUint(v, 10),
+	}
+}
+
+func uintLitF(f string, v uint64) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: fmt.Sprintf(f, v),
+	}
+}
+
+func ptrLit(v uintptr) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: "0x" + strconv.FormatUint(uint64(v), 16),
+	}
+}
+
+func ptrLitF(f string, v uintptr) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.INT,
+		Value: fmt.Sprintf(f, v),
+	}
+}
+
+func floatLit(v float64) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.FLOAT,
+		Value: strconv.FormatFloat(v, 'g', -1, 64),
+	}
+}
+
+func charLit(r rune) ast.Expr {
+	return &ast.BasicLit{
+		Kind:  token.CHAR,
+		Value: strconv.QuoteRuneToASCII(r),
+	}
+}
+
+func compositeLit(typ string, elts ...ast.Expr) ast.Expr {
+	return &ast.CompositeLit{Type: ident(typ), Elts: elts}
+}
+
+func compositeLitT(fields []*ast.Field, elts ...ast.Expr) ast.Expr {
+	return &ast.CompositeLit{
+		Type: &ast.StructType{Fields: &ast.FieldList{List: fields}},
+		Elts: elts,
+	}
+}
+
+func pair(k, v ast.Expr) ast.Expr {
+	return &ast.KeyValueExpr{Key: k, Value: v}
+}
+
+func callFunc(pkg, fnc string, args ...ast.Expr) ast.Expr {
+	var f ast.Expr = ident(fnc)
+	if pkg != "" {
+		f = sel(ident(pkg), fnc)
+	}
+	return call(f, args...)
+}
+
+func cast(x, to ast.Expr) ast.Expr {
+	if to == nil {
+		panic("type should not be nil")
+	}
+	return call(to, x)
+}
+
+func call(fnc ast.Expr, args ...ast.Expr) ast.Expr {
+	if fnc == nil {
+		panic("func should not be nil")
+	}
+	for i := range args {
+		switch a := args[i].(type) {
+		case *ast.ParenExpr:
+			args[i] = a.X
+		}
+	}
+	if s, ok := fnc.(*ast.SelectorExpr); ok {
+		if pkg, ok := s.X.(*ast.Ident); ok && pkg.Name == "unsafe" {
+			switch s.Sel.Name {
+			case "Offsetof", "Sizeof":
+				// Sizeof( (Struct{}).Fld ) -> Sizeof( Struct{}.Fld )
+				if len(args) == 1 {
+					if fs, ok := args[0].(*ast.SelectorExpr); ok {
+						if p, ok := fs.X.(*ast.ParenExpr); ok {
+							fs.X = p.X
+						}
+					}
+				}
+			}
+		}
+	}
+	return &ast.CallExpr{
+		Fun: fnc, Args: args,
+	}
+}
+
+func exprStmt(e ast.Expr) ast.Stmt {
+	return &ast.ExprStmt{X: e}
+}
+
+func sel(root ast.Expr, fld string) ast.Expr {
+	return selStmt(root, ident(fld))
+}
+
+func selStmt(root ast.Expr, fld *ast.Ident) ast.Expr {
+	switch r := root.(type) {
+	case *ast.CompositeLit:
+		root = &ast.ParenExpr{X: r}
+	}
+	return &ast.SelectorExpr{
+		X: root, Sel: fld,
+	}
+}
+
+func callPanic(e ast.Expr) ast.Stmt {
+	return exprStmt(
+		callFunc("", "panic", e),
+	)
+}
+
+func assertSizeof(v ast.Expr, sizeof int64) ast.Stmt {
+	// if n := unsafe.Sizeof(%v); n != %d { panic(n) }
+	return assertStmt(callFunc("unsafe", "Sizeof", v), intLit(sizeof))
+}
+
+func structOffsetTests(typ, fld string, offset, sizeof int64) []ast.Stmt {
+	// if n := unsafe.Offsetof(S%s{}.%s); n != %d { panic(n) }
+	// if n := unsafe.Sizeof(S%s{}.%s); n != %d { panic(n) }
+	f := sel(compositeLit(typ), fld)
+	return []ast.Stmt{
+		assertStmt(callFunc("unsafe", "Offsetof", f), intLit(offset)),
+		assertSizeof(f, sizeof),
+	}
+}
+
+func comment(s string) *ast.CommentGroup {
+	if strings.Contains(s, "\n") {
+		s = "/* " + s + " */"
+	} else {
+		s = "// " + s
+	}
+	return &ast.CommentGroup{
+		List: []*ast.Comment{
+			{Slash: 1, Text: s},
+		},
+	}
+}
+
+func commentf(s string, args ...interface{}) *ast.CommentGroup {
+	return comment(fmt.Sprintf(s, args...))
+}
+
+func commentDeclf(decl ast.Decl, s string, args ...interface{}) ast.Decl {
+	return commentDecl(decl, fmt.Sprintf(s, args...))
+}
+
+func commentDecl(decl ast.Decl, s string) ast.Decl {
+	if s == "" {
+		return decl
+	}
+	c := comment(s)
+	switch d := decl.(type) {
+	case *ast.FuncDecl:
+		d.Doc = c
+	case *ast.GenDecl:
+		d.Doc = c
+	default:
+		// FIXME
+	}
+	return decl
+}
+
+func commentSpecf(decl ast.Spec, s string, args ...interface{}) ast.Spec {
+	return commentSpec(decl, fmt.Sprintf(s, args...))
+}
+
+func commentSpec(decl ast.Spec, s string) ast.Spec {
+	if s == "" {
+		return decl
+	}
+	c := comment(s)
+	switch d := decl.(type) {
+	case *ast.ValueSpec:
+		d.Doc = c
+	default:
+		// FIXME
+	}
+	return decl
+}
+
+func commentStmtf(decl ast.Stmt, s string, args ...interface{}) ast.Stmt {
+	return commentStmt(decl, fmt.Sprintf(s, args...))
+}
+
+func commentStmt(decl ast.Stmt, s string) ast.Stmt {
+	if s == "" {
+		return decl
+	}
+	return decl // FIXME
+}
+
+func printDecls(w io.Writer, decls []ast.Decl) error {
+	fs := token.NewFileSet()
+	buf := bytes.NewBuffer(nil)
+	if err := format.Node(buf, fs, &ast.File{Name: ident("x"), Decls: decls}); err != nil {
+		return err
+	}
+	pref := []byte("package x")
+	data := buf.Bytes()
+	if !bytes.Contains(data, pref) {
+		return fmt.Errorf("prefix: %q", data[:len(pref)+1])
+	}
+	data = bytes.TrimPrefix(data, pref)
+	_, err := w.Write(data)
+	return err
+}
+
+func setPtr(x, v ast.Expr) ast.Stmt {
+	return assign(
+		ptrVal(x), v,
+	)
+}
+
+func unaddrUnsafe(typ string, x ast.Expr) ast.Expr {
+	return ptrVal(
+		cast(
+			toUnsafePtr(x),
+			ptr(ident(typ)),
+		),
+	)
+}
+
+func unaddrUnsafeN(typ string, n int, x ast.Expr) ast.Expr {
+	var t ast.Expr = ident(typ)
+	for i := 0; i < n; i++ {
+		t = ptr(t)
+	}
+	x = cast(toUnsafePtr(x), t)
+	for i := 0; i < n; i++ {
+		x = ptrVal(x)
+	}
+	return x
+}
+
+func setPtrUnsafe(typ string, x, v ast.Expr) ast.Stmt {
+	// *(*%s)(unsafe.Pointer(%s)) = %s
+	return assign(unaddrUnsafe(typ, x), v)
+}
+
+func withTLS(decl *ast.FuncDecl) *ast.FuncDecl {
+	par := decl.Type.Params
+	par.List = append([]*ast.Field{
+		{
+			Names: []*ast.Ident{ident("tls")},
+			Type:  sel(ident(crtP), "TLS"),
+		},
+	}, par.List...)
+	return decl
+}
+
+func eval(typ ast.Expr, stmts ...ast.Stmt) ast.Expr {
+	return &ast.CallExpr{
+		Fun: &ast.FuncLit{
+			Type: &ast.FuncType{
+				Params: &ast.FieldList{},
+				Results: &ast.FieldList{List: []*ast.Field{
+					field("", typ, nil),
+				}},
+			},
+			Body: block(stmts...),
+		},
+	}
+}
+
+func runAndReturn(ret, typ ast.Expr, stmts ...ast.Stmt) ast.Expr {
+	if len(stmts) == 0 {
+		return ret
+	}
+	stmts = append([]ast.Stmt{}, stmts...)
+	stmts = append(stmts, returnVal(ret))
+	return eval(typ, stmts...)
+}
+
+func returnVal(x ...ast.Expr) ast.Stmt {
+	return &ast.ReturnStmt{
+		Results: x,
+	}
+}
+
+func bool2int(x ast.Expr) ast.Expr {
+	return callFunc("", "bool2int", x)
+}
+
+func trimBits(x ast.Expr, n int) ast.Expr {
+	return paren(shr(shl(x, n), n))
+}
+
+func label(name string, stmts ...ast.Stmt) []ast.Stmt {
+	var s ast.Stmt = &ast.EmptyStmt{} // TODO: attach to the following statement
+	if len(stmts) != 0 {
+		s = stmts[0]
+		stmts = stmts[1:]
+	}
+	return append([]ast.Stmt{
+		&ast.LabeledStmt{
+			Label: ident(name),
+			Stmt:  s,
+		},
+	}, stmts...)
+}
+
+func labelN(n int, stmts ...ast.Stmt) []ast.Stmt {
+	return label(fmt.Sprintf("_%d", n), stmts...)
+}
+
+func gotoN(n int) ast.Stmt {
+	return gotoStmt(fmt.Sprintf("_%d", n))
+}
+
+func gotoStmt(name string) ast.Stmt {
+	return &ast.BranchStmt{Tok: token.GOTO, Label: ident(name)}
+}
+
+func defers(stmts ...ast.Stmt) ast.Stmt {
+	if len(stmts) == 1 {
+		if es, ok := stmts[0].(*ast.ExprStmt); ok {
+			if c, ok := es.X.(*ast.CallExpr); ok {
+				return &ast.DeferStmt{Call: c}
+			}
+		}
+	}
+	return &ast.DeferStmt{
+		Call: &ast.CallExpr{
+			Fun: &ast.FuncLit{
+				Type: &ast.FuncType{
+					Params: &ast.FieldList{},
+				},
+				Body: block(stmts...),
+			},
+		},
+	}
+}
+
+func rangeLoop(i, v string, arr ast.Expr, stmts ...ast.Stmt) ast.Stmt {
+	if i == "" {
+		i = "_"
+	}
+	var ve ast.Expr
+	if v != "" {
+		ve = ident(v)
+	}
+	return &ast.RangeStmt{
+		Tok: token.DEFINE,
+		Key: ident(i), Value: ve, X: arr,
+		Body: block(stmts...),
+	}
+}
+
+type stmtsArr [][]ast.Stmt
+
+func flattenStmts(arrs stmtsArr) []ast.Stmt {
+	return appendStmts(nil, arrs)
+}
+
+func appendStmts(dst []ast.Stmt, arrs stmtsArr) []ast.Stmt {
+	for _, arr := range arrs {
+		dst = append(dst, arr...)
+	}
+	return dst
+}
+
+func newTrue() *bool {
+	t := true
+	return &t
+}
+
+func switchStmt(x ast.Expr, cases ...*ast.CaseClause) ast.Stmt {
+	var stmts []ast.Stmt
+	for _, c := range cases {
+		stmts = append(stmts, c)
+	}
+	return &ast.SwitchStmt{
+		Tag: x, Body: block(stmts...),
+	}
+}
+
+func caseStmt(x ast.Expr, stmts ...ast.Stmt) *ast.CaseClause {
+	var list []ast.Expr
+	if x != nil {
+		list = []ast.Expr{x}
+	}
+	return &ast.CaseClause{
+		List: list, Body: stmts,
+	}
+}

--- a/internal/ccgo/type.go
+++ b/internal/ccgo/type.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cznic/ir"
 	"github.com/cznic/sqlite2go/internal/c99"
+	"go/ast"
 )
 
 type tCacheKey struct {
@@ -22,7 +23,16 @@ func isVaList(t c99.Type) bool {
 	return ok && (x.Name == idVaList || x.Name == idBuiltinVaList)
 }
 
+func (g *gen) castVA(n *c99.Expr, t c99.Type) ast.Expr {
+	return cast(
+		g.value(n, false),
+		sel(ident(crtP), "VA"+g.typ(c99.UnderlyingType(t))),
+	)
+}
+
 func (g *gen) typ(t c99.Type) string { return g.ptyp(t, true, 0) }
+
+func (g *gen) typI(t c99.Type) *ast.Ident { return ident(g.typ(t)) }
 
 func (g *gen) ptyp(t c99.Type, ptr2uintptr bool, lvl int) (r string) {
 	k := tCacheKey{t, ptr2uintptr}


### PR DESCRIPTION
Refactor the code to build Go AST instead of printing raw text. This will allow to build all optimizations directly into AST helpers and will allow to simplify the code further.

All tests pass, the only difference with original generated Go code - it's missing comments for arguments (see https://github.com/golang/go/issues/20744).

Based on #12.